### PR TITLE
Convert vertices to 0-based indices in has_edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## unreleased
+
+- `has_edge` now uses igraph's zero-based vertex indexing, and returns `false` for a vertex outside the graph instead of raising
+
 ## v1.0.0 - 2025-09-25
 
 - Update the underlying igraph C library to v1.0.0.

--- a/src/graph_api.jl
+++ b/src/graph_api.jl
@@ -35,7 +35,8 @@ Base.eltype(::IGraph) = LibIGraph.igraph_int_t
 Base.zero(::Type{IGraph}) = IGraph(0)
 # Graphs.edges # TODO
 Graphs.edgetype(g::IGraph) = Graphs.SimpleGraphs.SimpleEdge{eltype(g)} # TODO maybe expose the edge id information from IGraph
-Graphs.has_edge(g::IGraph,s,d) = LibIGraph.get_eid(g,s,d,false,false)[1]!=-1
+Graphs.has_edge(g::IGraph,s,d) =
+    Graphs.has_vertex(g,s) && Graphs.has_vertex(g,d) && LibIGraph.get_eid(g,s-1,d-1,false,false)[1]!=-1
 Graphs.has_vertex(g::IGraph,n::Integer) = 1≤n≤Graphs.nv(g)
 # Graphs.inneighbors # TODO
 Graphs.is_directed(::Type{IGraph}) = false # TODO support directed graphs

--- a/test/test_assorted_api.jl
+++ b/test/test_assorted_api.jl
@@ -18,6 +18,18 @@ using Test
     @test collect(v) == [0,2,1,0,1]
 end
 
+@testset "has_edge" begin
+    g = IGraph(Graphs.path_graph(4))
+    @test Graphs.has_edge(g, 3, 4)
+    @test Graphs.has_edge(g, 4, 3)
+    @test !Graphs.has_edge(g, 1, 3)
+    @test Graphs.has_edge(g, 1, 2) isa Bool
+    @test Graphs.has_edge(g, Graphs.SimpleEdge(3, 4))
+    for (s, d) in ((0, 1), (1, 0), (1, 5), (5, 1), (0, 0), (1, 100))
+        @test !Graphs.has_edge(g, s, d)
+    end
+end
+
 @testset "NULL input arguments" begin
     g = Graphs.smallgraph(:karate)
     ig = IGraph(g)

--- a/test/test_consistency.jl
+++ b/test/test_consistency.jl
@@ -11,6 +11,7 @@ for i in 1:100
     @test g2 == g
 
     @test LibIGraph.radius(ig,IGNull(),LibIGraph.IGRAPH_ALL)[1] == Graphs.radius(g) == Graphs.radius(g2)
+    @test all(Graphs.has_edge(ig,s,d) == Graphs.has_edge(g,s,d) for s in 1:10, d in 1:10)
 end
 
 end


### PR DESCRIPTION
`Graphs.has_edge` on an `IGraph` hands its vertices straight to `LibIGraph.get_eid`, which indexes from zero, while the rest of the wrapper presents the Julia convention of indexing from one: `IGraph(::AbstractSimpleGraph)` subtracts one when it adds edges, `vertices` returns `1:nv(g)`, and the `SimpleGraph` converter adds one back. So the method answers for the wrong pair, and once a vertex reaches `nv(g)` the zero-based call is out of range and igraph raises rather than returning an answer.

```julia
g = IGraph(path_graph(4))
has_edge(g, 3, 4)   # IGraphException IGRAPH_EINVVID, should be true
has_edge(g, 1, 4)   # IGraphException, should be false
has_edge(g, 0, 1)   # true, for a vertex that does not exist
```

The existing suite does not catch it because `has_edge` happens to give the right answer whenever the two vertices are consecutive, which is the case for every pair in a path graph and for the graphs used in `test_consistency.jl`.

The `has_vertex` guard is there because `get_eid` raises `IGraphException` for a vertex outside the graph while `SimpleGraph` returns `false`, so `has_edge(g, 0, 1)` and `has_edge(g, 1, nv(g) + 1)` now answer the way the Graphs.jl interface expects. Returning early also keeps the C call from ever seeing a negative vertex.

The checks go into the two files that already own this ground rather than a new one: the pairwise comparison against `SimpleGraph` joins the existing loop in `test_consistency.jl`, which already builds the graph and its wrapper, and the path-graph and out-of-range cases go in `test_assorted_api.jl`. Full suite on 1.10 is 378 passing, 267 of them pre-existing. Reverting `src/graph_api.jl` alone, keeping both tests, gives 270 passing, 90 failed and 18 errored, the errors being `get_eid` raising on the out-of-range vertices.

This is the same fix as the one in the closed #35, which was closed for lack of response rather than on its merits, and which #45 also carried. It is a piece of the interface work tracked in JuliaGraphs/Graphs.jl#446; I am not claiming that bounty.


AI Disclosure: Claude assisted with the code. Testing and review by @singhharsh1708.
