### PR TITLE
Fix JET checks on Julia 1.13

### DIFF
--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -4,6 +4,7 @@ using JET
 using Test
 using IGraphs
 
-JET.test_package(IGraphs, target_defined_modules = true)
+# Generated pointer accessors use getfield to reject unknown properties.
+JET.test_package(IGraphs, target_modules = (IGraphs,), ignored_modules = (IGraphs.LibIGraph,))
 
 end


### PR DESCRIPTION
Replace JET's removed `target_defined_modules` option and exclude generated C bindings that report intentional invalid-property errors.

Verified: `Pkg.test()` on Julia 1.10 and 1.13; JET analysis, documentation build, and benchmark smoke tests on 1.13.
